### PR TITLE
feat!: replace configurable DMP with perf-based heuristics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,6 @@ export type {
   UnsetPatch,
 } from './patches.js'
 
-export type {DiffMatchPatchOptions, DiffOptions, DocumentStub, PatchOptions} from './diffPatch.js'
+export type {DocumentStub, PatchOptions} from './diffPatch.js'
 
 export type {Path, PathSegment} from './paths.js'

--- a/test/__snapshots__/api.test.ts.snap
+++ b/test/__snapshots__/api.test.ts.snap
@@ -18,8 +18,19 @@ exports[`module api > can include ifRevisionID 1`] = `
       "set": {
         "arr[1]": null,
         "slug._type": "slug",
-        "slug.current": "die-hard-with-a-vengeance",
       },
+    },
+  },
+  {
+    "patch": {
+      "diffMatchPatch": {
+        "slug.current": "@@ -6,7 +6,20 @@
+ ard-
+-iii
++with-a-vengeance
+",
+      },
+      "id": "die-hard-iii",
     },
   },
 ]
@@ -42,8 +53,19 @@ exports[`module api > can pass different document ID 1`] = `
       "set": {
         "arr[1]": null,
         "slug._type": "slug",
-        "slug.current": "die-hard-with-a-vengeance",
       },
+    },
+  },
+  {
+    "patch": {
+      "diffMatchPatch": {
+        "slug.current": "@@ -6,7 +6,20 @@
+ ard-
+-iii
++with-a-vengeance
+",
+      },
+      "id": "moop",
     },
   },
 ]

--- a/test/__snapshots__/diff-match-patch.test.ts.snap
+++ b/test/__snapshots__/diff-match-patch.test.ts.snap
@@ -65,10 +65,13 @@ exports[`diff match patch > respects absolute length threshold 1`] = `
 [
   {
     "patch": {
-      "id": "die-hard-ix",
-      "set": {
-        "its": "also short",
+      "diffMatchPatch": {
+        "its": "@@ -1,5 +1,10 @@
++also 
+ short
+",
       },
+      "id": "die-hard-ix",
     },
   },
 ]
@@ -96,10 +99,79 @@ exports[`diff match patch > respects relative length threshold 1`] = `
 [
   {
     "patch": {
-      "id": "die-hard-ix",
-      "set": {
-        "synopsis": "When a sack of coffee explodes at the Ultra Gnoch asteroid, a man calling himself "Ziltoid" phones Major Case Unit Inspector Mark Cimino at the Tellus police station and claims responsibility for the sack. He orders suspended police officer Lt. John McClane to travel to the asteroid, in his underwear. McClane is flown there by Cimino and three other officers. Ultra Gnoch miner Dave Young spots McClane and tries to get him off the asteroid before the coffee bugs infiltrate the asteroid, but a gang of underpant gnomes attacks McClane and Young, who barely escape.",
+      "diffMatchPatch": {
+        "synopsis": "@@ -4,20 +4,21 @@
+ n a 
+-confetti cak
++sack of coffe
+ e ex
+@@ -35,38 +35,28 @@
+ the 
+-Bonwit Teller department store
++Ultra Gnoch asteroid
+ , a 
+@@ -80,13 +80,15 @@
+ lf %22
+-Simon
++Ziltoid
+ %22 ph
+@@ -122,27 +122,34 @@
+ tor 
+-Walter Cobb
++Mark Cimino
+  at the 
++Tellus 
+ poli
+@@ -197,16 +197,12 @@
+ the 
+-confetti
++sack
+ . He
+@@ -258,41 +258,30 @@
+  to 
+-walk through the middle of Harlem
++travel to the asteroid
+ , in
+@@ -311,13 +311,12 @@
+  is 
+-drive
++flow
+ n th
+@@ -327,11 +327,13 @@
+ by C
+-obb
++imino
+  and
+@@ -359,38 +359,36 @@
+ rs. 
+-Harlem electrician Zeus Carver
++Ultra Gnoch miner Dave Young
+  spo
+@@ -431,33 +431,62 @@
+ the 
++a
+ st
+-reet
++eroid
+  before 
++t
+ he 
+-is kille
++coffee bugs infiltrate the asteroi
+ d, b
+@@ -502,13 +502,23 @@
+  of 
+-youth
++underpant gnome
+ s at
+@@ -539,14 +539,13 @@
+ and 
+-Carver
++Young
+ , wh
+",
       },
+      "id": "die-hard-ix",
     },
   },
 ]

--- a/test/__snapshots__/if-revision.test.ts.snap
+++ b/test/__snapshots__/if-revision.test.ts.snap
@@ -8,8 +8,19 @@ exports[`ifRevisionID > can apply revision constraint (inferred from document) 1
       "ifRevisionID": "datrev",
       "set": {
         "rating": 4,
-        "title": "Die Hard with a Vengeance",
       },
+    },
+  },
+  {
+    "patch": {
+      "diffMatchPatch": {
+        "title": "@@ -6,5 +6,20 @@
+ ard 
+-3
++with a Vengeance
+",
+      },
+      "id": "die-hard-iii",
     },
   },
 ]
@@ -23,8 +34,19 @@ exports[`ifRevisionID > can apply revision constraint (uppercase) 1`] = `
       "ifRevisionID": "abc123",
       "set": {
         "rating": 4,
-        "title": "Die Hard with a Vengeance",
       },
+    },
+  },
+  {
+    "patch": {
+      "diffMatchPatch": {
+        "title": "@@ -6,5 +6,20 @@
+ ard 
+-3
++with a Vengeance
+",
+      },
+      "id": "die-hard-iii",
     },
   },
 ]

--- a/test/__snapshots__/object-arrays.test.ts.snap
+++ b/test/__snapshots__/object-arrays.test.ts.snap
@@ -46,10 +46,15 @@ exports[`object arrays > change item 1`] = `
 [
   {
     "patch": {
-      "id": "die-hard-iii",
-      "set": {
-        "characters[_key=="simon"].name": "Simon Grüber",
+      "diffMatchPatch": {
+        "characters[_key=="simon"].name": "@@ -5,8 +5,9 @@
+ n Gr
+-u
++%C3%BC
+ ber
+",
       },
+      "id": "die-hard-iii",
     },
   },
 ]
@@ -97,8 +102,19 @@ exports[`object arrays > remove from middle (single) 1`] = `
       "id": "die-hard-iii",
       "set": {
         "characters[1]._key": "zeus",
-        "characters[1].name": "Zeus Carver",
       },
+    },
+  },
+  {
+    "patch": {
+      "diffMatchPatch": {
+        "characters[1].name": "@@ -1,12 +1,11 @@
+-Simon Grub
++Zeus Carv
+ er
+",
+      },
+      "id": "die-hard-iii",
     },
   },
 ]

--- a/test/__snapshots__/primitive-arrays.test.ts.snap
+++ b/test/__snapshots__/primitive-arrays.test.ts.snap
@@ -71,10 +71,14 @@ exports[`primitive arrays > remove from middle (single) 1`] = `
   },
   {
     "patch": {
-      "id": "die-hard-iii",
-      "set": {
-        "characters[1]": "Zeus Carver",
+      "diffMatchPatch": {
+        "characters[1]": "@@ -1,12 +1,11 @@
+-Simon Grub
++Zeus Carv
+ er
+",
       },
+      "id": "die-hard-iii",
     },
   },
 ]

--- a/test/__snapshots__/pt.test.ts.snap
+++ b/test/__snapshots__/pt.test.ts.snap
@@ -13,10 +13,13 @@ exports[`portable text > undo bold change 1`] = `
   },
   {
     "patch": {
-      "id": "die-hard-iii",
-      "set": {
-        "portableText[_key=="920ebbba9ada"].children[_key=="80847f72abfd"].text": "La oss begynne med en empty slate.",
+      "diffMatchPatch": {
+        "portableText[_key=="920ebbba9ada"].children[_key=="80847f72abfd"].text": "@@ -15,8 +15,20 @@
+  med en 
++empty slate.
+",
       },
+      "id": "die-hard-iii",
     },
   },
 ]

--- a/test/__snapshots__/set-unset.test.ts.snap
+++ b/test/__snapshots__/set-unset.test.ts.snap
@@ -7,8 +7,19 @@ exports[`set/unset > basic nested changes 1`] = `
       "id": "die-hard-iii",
       "set": {
         "slug._type": "slug",
-        "slug.current": "die-hard-with-a-vengeance",
       },
+    },
+  },
+  {
+    "patch": {
+      "diffMatchPatch": {
+        "slug.current": "@@ -6,7 +6,20 @@
+ ard-
+-iii
++with-a-vengeance
+",
+      },
+      "id": "die-hard-iii",
     },
   },
 ]
@@ -26,11 +37,17 @@ exports[`set/unset > deep nested changes 1`] = `
   },
   {
     "patch": {
-      "id": "die-hard-iii",
-      "set": {
-        "products[_key=="item-1"].comparisonFields['support-level']": "advanced",
-        "products[_key=="item-1"].variants[_key=="variant-1"]['lace-type']": "slick",
+      "diffMatchPatch": {
+        "products[_key=="item-1"].comparisonFields['support-level']": "@@ -1,5 +1,8 @@
+-basic
++advanced
+",
+        "products[_key=="item-1"].variants[_key=="variant-1"]['lace-type']": "@@ -1,5 +1,5 @@
+-waxed
++slick
+",
       },
+      "id": "die-hard-iii",
     },
   },
 ]
@@ -73,8 +90,19 @@ exports[`set/unset > set + unset, nested changes 1`] = `
       "set": {
         "arr[1]": null,
         "slug._type": "slug",
-        "slug.current": "die-hard-with-a-vengeance",
       },
+    },
+  },
+  {
+    "patch": {
+      "diffMatchPatch": {
+        "slug.current": "@@ -6,7 +6,20 @@
+ ard-
+-iii
++with-a-vengeance
+",
+      },
+      "id": "die-hard-iii",
     },
   },
 ]
@@ -87,8 +115,19 @@ exports[`set/unset > simple root-level changes 1`] = `
       "id": "die-hard-iii",
       "set": {
         "rating": 4,
-        "title": "Die Hard with a Vengeance",
       },
+    },
+  },
+  {
+    "patch": {
+      "diffMatchPatch": {
+        "title": "@@ -6,5 +6,20 @@
+ ard 
+-3
++with a Vengeance
+",
+      },
+      "id": "die-hard-iii",
     },
   },
 ]

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -25,7 +25,7 @@ describe('module api', () => {
 
   test('does not throw if ids do not match and id is provided', () => {
     const b = {...setAndUnset.b, _id: 'zing'}
-    expect(diffPatch(setAndUnset.a, b, {id: 'yup', hideWarnings: true})).toHaveLength(2)
+    expect(diffPatch(setAndUnset.a, b, {id: 'yup', hideWarnings: true})).toHaveLength(3)
   })
 
   test('pathToString throws on invalid path segments', () => {

--- a/test/data-types.test.ts
+++ b/test/data-types.test.ts
@@ -10,12 +10,19 @@ describe('diff data types', () => {
         patch: {
           id: dataTypes.a._id,
           set: {
-            title: 'Die Hard with a Vengeance',
-            rating: 4.24,
             isFeatured: false,
-            'characters[0]': 'Simon Gruber',
-            'slug.current': 'die-hard-with-a-vengeance',
+            rating: 4.24,
             year: 1995,
+          },
+        },
+      },
+      {
+        patch: {
+          id: 'die-hard-iii',
+          diffMatchPatch: {
+            title: '@@ -6,5 +6,20 @@\n ard \n-3\n+with a Vengeance\n',
+            'characters[0]': '@@ -1,12 +1,12 @@\n-John McClane\n+Simon Gruber\n',
+            'slug.current': '@@ -6,7 +6,20 @@\n ard-\n-iii\n+with-a-vengeance\n',
           },
         },
       },
@@ -65,8 +72,13 @@ describe('diff data types', () => {
             number: 1337,
             'object.b12': '12',
             'object.f13': null,
-            string: 'bar',
           },
+        },
+      },
+      {
+        patch: {
+          id: 'abc123',
+          diffMatchPatch: {string: '@@ -1,3 +1,3 @@\n-foo\n+bar\n'},
         },
       },
     ])


### PR DESCRIPTION
This PR introduces a **BREAKING CHANGE** by removing the user-configurable options for `diff-match-patch` (DMP) behavior. Instead, the library now employs a set of automatic, performance-tested heuristics to determine when to use DMP for string diffs versus falling back to a simple `set` operation.

This change aims to simplify the API, provide more consistent and optimized behavior out-of-the-box, and better handle real-world editing scenarios like keystrokes and copy-paste operations, while avoiding known performance pitfalls of DMP on large text replacements.

**Key Changes:**

*   **BREAKING CHANGE:**
    *   Removed the `diffMatchPatch` options (`enabled`, `lengthThresholdAbsolute`, `lengthThresholdRelative`) from `PatchOptions`.
    *   Removed the `DiffMatchPatchOptions` and `DiffOptions` (which included `diffMatchPatch`) interfaces from the public API.
    *   Removed the internal `mergeOptions` function and the DMP-specific parts of `defaultOptions`.
*   **New Performance-Based Heuristics for DMP:**
    *   Introduced a new exported utility function `shouldUseDiffMatchPatch(source: string, target: string): boolean`. This function encapsulates the new logic for deciding whether to use DMP.
    *   The decision is now based on:
        *   **Document Size Limit:** Documents larger than 1MB (`DMP_MAX_DOCUMENT_SIZE`) will use `set` operations.
        *   **Change Ratio Threshold:** If more than 40% (`DMP_MAX_CHANGE_RATIO`) of the text changes, `set` is used (indicates replacement vs. editing).
        *   **Small Document Optimization:** Documents smaller than 10KB (`DMP_MIN_SIZE_FOR_RATIO_CHECK`) always use DMP, as performance is consistently high for these.
        *   **System Key Protection:** Properties starting with `_` (system keys) continue to use `set` operations.
    *   Added extensive JSDoc to `shouldUseDiffMatchPatch` detailing the heuristic rationale, performance characteristics (based on testing `@sanity/diff-match-patch` on an M2 MacBook Pro), algorithm details, and test methodology.
*   **Internal Simplification:**
    *   The internal `getDiffMatchPatch` function now uses `shouldUseDiffMatchPatch` to make its decision and no longer accepts DMP-related options.
    *   Simplified the call to the underlying `@sanity/diff-match-patch` library within `getDiffMatchPatch` to use `makePatches(source, target)` directly. This is more concise and leverages the internal optimizations of that library, with performance validated to be equivalent to the previous multi-step approach.
*   **Constants:** Introduced `SYSTEM_KEYS`, `DMP_MAX_DOCUMENT_SIZE`, `DMP_MAX_CHANGE_RATIO`, and `DMP_MIN_SIZE_FOR_RATIO_CHECK` to define these thresholds.
*   **Test Updates:** Snapshots have been updated to reflect the new DMP behavior based on these heuristics.

**Rationale for Change:**

The previous configurable thresholds for DMP were somewhat arbitrary and could lead to suboptimal performance or overly verbose patches in certain scenarios. This change is based on empirical performance testing of the `@sanity/diff-match-patch` library itself. The new heuristics are designed to:

*   **Optimize for common editing patterns:** Ensure fast performance for keystrokes and small pastes, which are the most frequent operations.
*   **Prevent performance degradation:** Avoid triggering complex and potentially slow DMP algorithm paths when users perform large text replacements (e.g., pasting entirely new content).
*   **Simplify the API:** Remove the burden of configuration from the user, providing sensible defaults.
*   **Maintain conflict-resistance:** Continue to leverage DMP's strengths for collaborative editing where appropriate.

By hardcoding these well-tested heuristics, we aim for a more robust and performant string diffing strategy by default.
