### PR TITLE
feat!: remove undefined-to-null conversion warnings and simplify internal APIs

### DIFF
--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -5,27 +5,23 @@ import * as setAndUnset from './fixtures/set-and-unset'
 
 describe('module api', () => {
   test('can include ifRevisionID', () => {
-    expect(
-      diffPatch(setAndUnset.a, setAndUnset.b, {ifRevisionID: 'foo', hideWarnings: true}),
-    ).toMatchSnapshot()
+    expect(diffPatch(setAndUnset.a, setAndUnset.b, {ifRevisionID: 'foo'})).toMatchSnapshot()
   })
 
   test('can pass different document ID', () => {
-    expect(
-      diffPatch(setAndUnset.a, setAndUnset.b, {id: 'moop', hideWarnings: true}),
-    ).toMatchSnapshot()
+    expect(diffPatch(setAndUnset.a, setAndUnset.b, {id: 'moop'})).toMatchSnapshot()
   })
 
   test('throws if ids do not match', () => {
     const b = {...setAndUnset.b, _id: 'zing'}
-    expect(() => diffPatch(setAndUnset.a, b, {hideWarnings: true})).toThrowError(
+    expect(() => diffPatch(setAndUnset.a, b)).toThrowError(
       `_id on itemA and itemB not present or differs, specify document id the mutations should be applied to`,
     )
   })
 
   test('does not throw if ids do not match and id is provided', () => {
     const b = {...setAndUnset.b, _id: 'zing'}
-    expect(diffPatch(setAndUnset.a, b, {id: 'yup', hideWarnings: true})).toHaveLength(3)
+    expect(diffPatch(setAndUnset.a, b, {id: 'yup'})).toHaveLength(3)
   })
 
   test('pathToString throws on invalid path segments', () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -117,7 +117,7 @@ describe.skipIf(lacksConfig)(
 
         const input = {...fix.fixture.input, _id, _type}
         const output = {...fix.fixture.output, _id, _type}
-        const diff = diffPatch(input, output, {hideWarnings: true})
+        const diff = diffPatch(input, output)
 
         const trx = client.transaction().createOrReplace(input).serialize()
 

--- a/test/pt.test.ts
+++ b/test/pt.test.ts
@@ -4,6 +4,6 @@ import * as fixture from './fixtures/portableText'
 
 describe('portable text', () => {
   test('undo bold change', () => {
-    expect(diffPatch(fixture.a, fixture.b, {hideWarnings: true})).toMatchSnapshot()
+    expect(diffPatch(fixture.a, fixture.b)).toMatchSnapshot()
   })
 })

--- a/test/set-unset.test.ts
+++ b/test/set-unset.test.ts
@@ -8,26 +8,26 @@ import * as simple from './fixtures/simple'
 
 describe('set/unset', () => {
   test('simple root-level changes', () => {
-    expect(diffPatch(simple.a, simple.b, {hideWarnings: true})).toMatchSnapshot()
+    expect(diffPatch(simple.a, simple.b)).toMatchSnapshot()
   })
 
   test('basic nested changes', () => {
-    expect(diffPatch(nested.a, nested.b, {hideWarnings: true})).toMatchSnapshot()
+    expect(diffPatch(nested.a, nested.b)).toMatchSnapshot()
   })
 
   test('set + unset, nested changes', () => {
-    expect(diffPatch(setAndUnset.a, setAndUnset.b, {hideWarnings: true})).toMatchSnapshot()
+    expect(diffPatch(setAndUnset.a, setAndUnset.b)).toMatchSnapshot()
   })
 
   test('set + unset, image example', () => {
-    expect(diffPatch(image.a, image.b, {hideWarnings: true})).toMatchSnapshot()
+    expect(diffPatch(image.a, image.b)).toMatchSnapshot()
   })
 
   test('deep nested changes', () => {
-    expect(diffPatch(deep.a, deep.b, {hideWarnings: true})).toMatchSnapshot()
+    expect(diffPatch(deep.a, deep.b)).toMatchSnapshot()
   })
 
   test('no diff', () => {
-    expect(diffPatch(nested.a, nested.a, {hideWarnings: true})).toEqual([])
+    expect(diffPatch(nested.a, nested.a)).toEqual([])
   })
 })


### PR DESCRIPTION
This PR introduces two related changes to simplify the library's API and internal logic:

1.  **Removes Console Warnings for `undefined` to `null` Conversion:**
    The library previously logged a console warning when an `undefined` value within an array was converted to `null` during the diffing process. This warning has been removed. The conversion itself remains (as `undefined` is not valid JSON and `null` is the standard representation for "no value"), but it will no longer produce console output.
2.  **Simplifies Internal APIs by Removing `options` Propagation:**
    The `hideWarnings` option was the primary reason for propagating the `options` object deep into various internal diffing functions (`diffItem`, `diffObject`, `diffArray`, `diffArrayByIndex`, `diffArrayByKey`). With the removal of the warning and the `hideWarnings` option, this propagation is no longer necessary. These internal functions now have simpler signatures, no longer accepting or passing down the `options` object for this purpose.

**Key Changes:**

*   **`nullifyUndefined` Function:**
    *   Removed the `path`, `index`, and `options` parameters.
    *   Removed the conditional `console.warn` log.
    *   The function now solely converts `undefined` to `null`, aligning its behavior more closely with `JSON.stringify()` without side effects.
    *   Updated JSDoc to reflect this simplified behavior.
*   **Removal of `hideWarnings` Option:**
    *   Removed the `hideWarnings` property from the `PatchOptions` interface.
    *   Removed `DEFAULT_OPTIONS` constant as it's no longer needed.
*   **Simplified Internal Function Signatures:**
    *   The `options` parameter has been removed from `diffItem`, `diffObject`, `diffArray`, `diffArrayByIndex`, and `diffArrayByKey` as it was primarily used for `hideWarnings`. These functions now rely on the default behavior for `undefined` handling.
*   **Test Updates:**
    *   Removed `hideWarnings: true` from test calls to `diffPatch`.
    *   Snapshots remain largely the same in terms of patch output, as the core diffing logic for values is unaffected, only the warning and option handling.

**Rationale:**

*   **Cleaner Console Output:** Removing the `undefined` to `null` conversion warning reduces noise in the console, especially for users who frequently work with data that might contain `undefined` values. The conversion to `null` is a standard and expected behavior when serializing to JSON-like structures.
*   **Simplified API:** Removing the `hideWarnings` option makes the public API slightly leaner.
*   **Internal Code Simplification:** Eliminating the need to pass the `options` object through multiple internal functions for the sole purpose of `hideWarnings` leads to cleaner and more maintainable internal code.
*   **Alignment with `JSON.stringify`:** The behavior of converting `undefined` in arrays to `null` is consistent with `JSON.stringify`, making the library's behavior more predictable for developers familiar with JSON standards.

This change streamlines the library's behavior regarding `undefined` values and simplifies its internal option handling.