### PR TITLE
feat: add key-based reordering support for keyed object arrays

### DIFF
--- a/src/patches.ts
+++ b/src/patches.ts
@@ -1,4 +1,4 @@
-import type {Path} from './paths.js'
+import type {KeyedSanityObject, Path} from './paths.js'
 
 /**
  * A `set` operation
@@ -29,9 +29,10 @@ export interface UnsetPatch {
  *
  * @internal
  */
-export interface InsertAfterPatch {
+export interface InsertPatch {
   op: 'insert'
-  after: Path
+  position: 'before' | 'after' | 'replace'
+  path: Path
   items: any[]
 }
 
@@ -48,11 +49,25 @@ export interface DiffMatchPatch {
 }
 
 /**
+ * A `reorder` operation used to ...
+ *
+ * Note: NOT a serializable mutation.
+ *
+ * @public
+ */
+export interface ReorderPatch {
+  op: 'reorder'
+  path: Path
+  snapshot: KeyedSanityObject[]
+  reorders: {sourceKey: string; targetKey: string}[]
+}
+
+/**
  * Internal patch representation used during diff generation
  *
  * @internal
  */
-export type Patch = SetPatch | UnsetPatch | InsertAfterPatch | DiffMatchPatch
+export type Patch = SetPatch | UnsetPatch | InsertPatch | DiffMatchPatch | ReorderPatch
 
 /**
  * A Sanity `set` patch mutation operation

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,5 +1,3 @@
-import type {KeyedSanityObject} from './diffPatch.js'
-
 const IS_DOTTABLE_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
 
 /**
@@ -54,6 +52,16 @@ export function pathToString(path: Path): string {
   }, '')
 }
 
-function isKeyedObject(obj: any): obj is KeyedSanityObject {
-  return typeof obj === 'object' && typeof obj._key === 'string'
+/**
+ * An object (record) that has a `_key` property
+ *
+ * @internal
+ */
+export interface KeyedSanityObject {
+  [key: string]: unknown
+  _key: string
+}
+
+export function isKeyedObject(obj: unknown): obj is KeyedSanityObject {
+  return typeof obj === 'object' && !!obj && '_key' in obj && typeof obj._key === 'string'
 }

--- a/src/setOperations.ts
+++ b/src/setOperations.ts
@@ -1,0 +1,29 @@
+/// <reference lib="esnext" />
+
+export function difference<T>(source: Set<T>, target: Set<T>): Set<T> {
+  if ('difference' in Set.prototype) {
+    return source.difference(target)
+  }
+
+  const result = new Set<T>()
+  for (const item of source) {
+    if (!target.has(item)) {
+      result.add(item)
+    }
+  }
+  return result
+}
+
+export function intersection<T>(source: Set<T>, target: Set<T>): Set<T> {
+  if ('intersection' in Set.prototype) {
+    return source.intersection(target)
+  }
+
+  const result = new Set<T>()
+  for (const item of source) {
+    if (target.has(item)) {
+      result.add(item)
+    }
+  }
+  return result
+}

--- a/test/__snapshots__/object-arrays.test.ts.snap
+++ b/test/__snapshots__/object-arrays.test.ts.snap
@@ -6,7 +6,7 @@ exports[`object arrays > add to end (multiple) 1`] = `
     "patch": {
       "id": "die-hard-iii",
       "insert": {
-        "after": "characters[-1]",
+        "after": "characters[_key=="john"]",
         "items": [
           {
             "_key": "simon",
@@ -29,7 +29,7 @@ exports[`object arrays > add to end (single) 1`] = `
     "patch": {
       "id": "die-hard-iii",
       "insert": {
-        "after": "characters[-1]",
+        "after": "characters[_key=="john"]",
         "items": [
           {
             "_key": "simon",
@@ -93,28 +93,217 @@ exports[`object arrays > remove from middle (single) 1`] = `
     "patch": {
       "id": "die-hard-iii",
       "unset": [
-        "characters[_key=="zeus"]",
+        "characters[_key=="simon"]",
       ],
+    },
+  },
+]
+`;
+
+exports[`object arrays > reorder (complete reverse) 1`] = `
+[
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "set": {
+        "characters[_key=="john"]": {
+          "_key": "__temp_reorder_john__",
+          "name": "Zeus Carver",
+        },
+        "characters[_key=="zeus"]": {
+          "_key": "__temp_reorder_zeus__",
+          "name": "John McClane",
+        },
+      },
     },
   },
   {
     "patch": {
       "id": "die-hard-iii",
       "set": {
-        "characters[1]._key": "zeus",
+        "characters[_key=="__temp_reorder_john__"]._key": "zeus",
+        "characters[_key=="__temp_reorder_zeus__"]._key": "john",
+      },
+    },
+  },
+]
+`;
+
+exports[`object arrays > reorder (simple swap) 1`] = `
+[
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "set": {
+        "characters[_key=="john"]": {
+          "_key": "__temp_reorder_john__",
+          "name": "Simon Gruber",
+        },
+        "characters[_key=="simon"]": {
+          "_key": "__temp_reorder_simon__",
+          "name": "John McClane",
+        },
+      },
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "set": {
+        "characters[_key=="__temp_reorder_john__"]._key": "simon",
+        "characters[_key=="__temp_reorder_simon__"]._key": "john",
+      },
+    },
+  },
+]
+`;
+
+exports[`object arrays > reorder with content change 1`] = `
+[
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "set": {
+        "characters[_key=="john"]": {
+          "_key": "__temp_reorder_john__",
+          "name": "Zeus Carver",
+        },
+        "characters[_key=="simon"]": {
+          "_key": "__temp_reorder_simon__",
+          "name": "John McClane",
+        },
+        "characters[_key=="zeus"]": {
+          "_key": "__temp_reorder_zeus__",
+          "name": "Simon Gruber",
+        },
+      },
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "set": {
+        "characters[_key=="__temp_reorder_john__"]._key": "zeus",
+        "characters[_key=="__temp_reorder_simon__"]._key": "john",
+        "characters[_key=="__temp_reorder_zeus__"]._key": "simon",
       },
     },
   },
   {
     "patch": {
       "diffMatchPatch": {
-        "characters[1].name": "@@ -1,12 +1,11 @@
--Simon Grub
-+Zeus Carv
- er
+        "characters[_key=="zeus"].name": "@@ -4,8 +4,12 @@
+ s Carver
++ Jr.
 ",
       },
       "id": "die-hard-iii",
+    },
+  },
+]
+`;
+
+exports[`object arrays > reorder with insertion and deletion 1`] = `
+[
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "set": {
+        "characters[_key=="john"]": {
+          "_key": "__temp_reorder_john__",
+          "name": "Zeus Carver",
+        },
+        "characters[_key=="zeus"]": {
+          "_key": "__temp_reorder_zeus__",
+          "name": "John McClane",
+        },
+      },
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "set": {
+        "characters[_key=="__temp_reorder_john__"]._key": "zeus",
+        "characters[_key=="__temp_reorder_zeus__"]._key": "john",
+      },
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "unset": [
+        "characters[_key=="simon"]",
+      ],
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "insert": {
+        "after": "characters[_key=="zeus"]",
+        "items": [
+          {
+            "_key": "hans",
+            "name": "Hans Gruber",
+          },
+        ],
+      },
+    },
+  },
+]
+`;
+
+exports[`object arrays > reorder with size change (multiple insertions) 1`] = `
+[
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "set": {
+        "characters[_key=="john"]": {
+          "_key": "__temp_reorder_john__",
+          "name": "Zeus Carver",
+        },
+        "characters[_key=="zeus"]": {
+          "_key": "__temp_reorder_zeus__",
+          "name": "John McClane",
+        },
+      },
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "set": {
+        "characters[_key=="__temp_reorder_john__"]._key": "zeus",
+        "characters[_key=="__temp_reorder_zeus__"]._key": "john",
+      },
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "unset": [
+        "characters[_key=="simon"]",
+      ],
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "insert": {
+        "after": "characters[_key=="john"]",
+        "items": [
+          {
+            "_key": "hans",
+            "name": "Hans Gruber",
+          },
+          {
+            "_key": "karl",
+            "name": "Karl Vreski",
+          },
+        ],
+      },
     },
   },
 ]

--- a/test/__snapshots__/pt.test.ts.snap
+++ b/test/__snapshots__/pt.test.ts.snap
@@ -4,15 +4,6 @@ exports[`portable text > undo bold change 1`] = `
 [
   {
     "patch": {
-      "id": "die-hard-iii",
-      "unset": [
-        "portableText[_key=="920ebbba9ada"].children[_key=="1bda8032e34c"]",
-        "portableText[_key=="920ebbba9ada"].children[_key=="cb0568a8e746"]",
-      ],
-    },
-  },
-  {
-    "patch": {
       "diffMatchPatch": {
         "portableText[_key=="920ebbba9ada"].children[_key=="80847f72abfd"].text": "@@ -15,8 +15,20 @@
   med en 
@@ -20,6 +11,15 @@ exports[`portable text > undo bold change 1`] = `
 ",
       },
       "id": "die-hard-iii",
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "unset": [
+        "portableText[_key=="920ebbba9ada"].children[_key=="1bda8032e34c"]",
+        "portableText[_key=="920ebbba9ada"].children[_key=="cb0568a8e746"]",
+      ],
     },
   },
 ]

--- a/test/fixtures/object-array-reorder.ts
+++ b/test/fixtures/object-array-reorder.ts
@@ -1,0 +1,72 @@
+export const a = {
+  _id: 'die-hard-iii',
+  title: 'Die Hard with a Vengeance',
+  characters: [
+    {_key: 'john', name: 'John McClane'},
+    {_key: 'simon', name: 'Simon Gruber'},
+    {_key: 'zeus', name: 'Zeus Carver'},
+  ],
+}
+
+// Simple reorder: swap first two items
+export const b = {
+  _id: 'die-hard-iii',
+  title: 'Die Hard with a Vengeance',
+  characters: [
+    {_key: 'simon', name: 'Simon Gruber'},
+    {_key: 'john', name: 'John McClane'},
+    {_key: 'zeus', name: 'Zeus Carver'},
+  ],
+}
+
+// Complex reorder: completely reverse the array
+export const c = {
+  _id: 'die-hard-iii',
+  title: 'Die Hard with a Vengeance',
+  characters: [
+    {_key: 'zeus', name: 'Zeus Carver'},
+    {_key: 'simon', name: 'Simon Gruber'},
+    {_key: 'john', name: 'John McClane'},
+  ],
+}
+
+// Reorder with content change: move zeus to front and change his name
+export const d = {
+  _id: 'die-hard-iii',
+  title: 'Die Hard with a Vengeance',
+  characters: [
+    {_key: 'zeus', name: 'Zeus Carver Jr.'},
+    {_key: 'john', name: 'John McClane'},
+    {_key: 'simon', name: 'Simon Gruber'},
+  ],
+}
+
+// Complex scenario: reorder + insertion + deletion
+// - Remove simon (deletion)
+// - Add hans as new villain (insertion)
+// - Reorder zeus to front, john to end (reordering)
+export const e = {
+  _id: 'die-hard-iii',
+  title: 'Die Hard with a Vengeance',
+  characters: [
+    {_key: 'zeus', name: 'Zeus Carver'},
+    {_key: 'hans', name: 'Hans Gruber'},
+    {_key: 'john', name: 'John McClane'},
+  ],
+}
+
+// Complex scenario with size change: reorder + multiple insertions + deletion
+// - Remove simon (deletion)
+// - Add hans and karl as new villains (2 insertions)
+// - Reorder zeus to front, john to middle (reordering)
+// Result: array grows from 3 to 4 items
+export const f = {
+  _id: 'die-hard-iii',
+  title: 'Die Hard with a Vengeance',
+  characters: [
+    {_key: 'zeus', name: 'Zeus Carver'},
+    {_key: 'john', name: 'John McClane'},
+    {_key: 'hans', name: 'Hans Gruber'},
+    {_key: 'karl', name: 'Karl Vreski'},
+  ],
+}

--- a/test/object-arrays.test.ts
+++ b/test/object-arrays.test.ts
@@ -3,6 +3,7 @@ import {diffPatch} from '../src'
 import * as objectArrayAdd from './fixtures/object-array-add'
 import * as objectArrayRemove from './fixtures/object-array-remove'
 import * as objectArrayChange from './fixtures/object-array-change'
+import * as objectArrayReorder from './fixtures/object-array-reorder'
 
 describe('object arrays', () => {
   test('change item', () => {
@@ -27,5 +28,25 @@ describe('object arrays', () => {
 
   test('remove from middle (single)', () => {
     expect(diffPatch(objectArrayRemove.a, objectArrayRemove.d)).toMatchSnapshot()
+  })
+
+  test('reorder (simple swap)', () => {
+    expect(diffPatch(objectArrayReorder.a, objectArrayReorder.b)).toMatchSnapshot()
+  })
+
+  test('reorder (complete reverse)', () => {
+    expect(diffPatch(objectArrayReorder.a, objectArrayReorder.c)).toMatchSnapshot()
+  })
+
+  test('reorder with content change', () => {
+    expect(diffPatch(objectArrayReorder.a, objectArrayReorder.d)).toMatchSnapshot()
+  })
+
+  test('reorder with insertion and deletion', () => {
+    expect(diffPatch(objectArrayReorder.a, objectArrayReorder.e)).toMatchSnapshot()
+  })
+
+  test('reorder with size change (multiple insertions)', () => {
+    expect(diffPatch(objectArrayReorder.a, objectArrayReorder.f)).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
This PR introduces a significant enhancement to how keyed object arrays are diffed and patched: **support for key-based reordering**.

Previously, `diffArrayByKey` would fall back to index-based diffing if the order of keys changed between the source and target arrays. This could lead to less precise or less conflict-resistant patches when items were simply moved around.

With this change, `diffArrayByKey` now:
1.  Detects reordering, insertions, and deletions independently.
2.  Generates a new internal `ReorderPatch` type when items change position.
3.  Emits `insert` and `unset` patches for items added or removed.
4.  Continues to diff the content of items that exist in both arrays (even if reordered).

The `serializePatches` function has been updated to handle the new `ReorderPatch`. It employs a **two-phase reordering strategy** to avoid key collisions during the patch application:
*   **Phase 1:** Moves all reordered items to temporary keys (`__temp_reorder_<originalKey>__`) while applying their final content.
*   **Phase 2:** Updates only the `_key` property of these temporary items to restore their intended final keys.

This two-phase approach ensures that direct key swaps (e.g., A ↔ B) are handled correctly without data loss.

**Key Changes:**

*   **`diffArrayByKey` Overhaul:**
    *   No longer falls back to `diffArrayByIndex` if key order changes.
    *   Uses `Map` for efficient key-based lookups.
    *   Utilizes new `difference` and `intersection` set operations (from `setOperations.ts`) to categorize keys (removed, added, common).
    *   Detects reordering by comparing relative positions of keys present in both source and target.
    *   If reordering is detected, a new `ReorderPatch` is pushed to the `patches` array, containing the original array `snapshot` and the specific `reorders` (sourceKey → targetKey).
    *   Handles insertions of new items, batching consecutive insertions and using `position: 'before'` or `position: 'after'` based on the surrounding existing keys.
    *   Handles deletions of items no longer present.
    *   Item content changes are still diffed using `diffItem`.
*   **New `ReorderPatch` Type (Internal):**
    *   Added `ReorderPatch` to the internal `Patch` union in `patches.ts`.
    *   `ReorderPatch` includes `op: 'reorder'`, `path`, `snapshot` (the original array), and `reorders` (an array of `{sourceKey, targetKey}` pairs).
*   **`serializePatches` Handling of `ReorderPatch`:**
    *   When a `ReorderPatch` is encountered:
        *   It emits two separate `set` patch operations.
        *   **Phase 1 Set:** Sets the content of items at their *original* keyed paths (`_key: sourceKey`) to be the *final* content of the item that will occupy that position, but with a temporary `_key` (e.g., `_key: "__temp_reorder_sourceKey__"`).
        *   **Phase 2 Set:** Sets the `_key` property of these temporary items (e.g., `path: 'array[_key=="__temp_reorder_sourceKey__"]._key'`) to their final `targetKey`.
*   **New `setOperations.ts`:**
    *   Added `difference` and `intersection` utility functions for `Set<T>`. These use native `Set.prototype.difference/intersection` if available (ESNext) or provide fallbacks for older JS environments.
*   **New `KeyedSanityObject` and `isKeyedObject` in `paths.ts`:**
    *   Moved `KeyedSanityObject` type definition from `diffPatch.ts` to `paths.ts`.
    *   Improved `isKeyedObject` type guard for robustness.
*   **New `getIndexForKey` Utility:**
    *   Added a cached utility in `diffPatch.ts` to efficiently get the index of an item in a keyed array.
*   **`diffArray` Logic Update:**
    *   Now checks if *both* source and target arrays are uniquely keyed before calling `diffArrayByKey`. Otherwise, it falls back to `diffArrayByIndex`.
    *   Insertions for non-keyed arrays now use `position: 'after'` and `path: path.concat([-1])`.
*   **Updated `InsertPatch` Type:**
    *   The internal `InsertPatch` (previously `InsertAfterPatch`) now includes a `position: 'before' | 'after' | 'replace'` property and uses `path` instead of just `after`.
    *   `serializePatches` updated to use `patch.position` when creating the `SanityInsertPatchOperation`.
*   **New Test Fixtures and Tests:**
    *   Added `test/fixtures/object-array-reorder.ts` with various reordering scenarios (simple swap, complete reverse, reorder with content change, reorder with insertions/deletions).
    *   Added corresponding tests in `test/object-arrays.test.ts` to verify these scenarios.
    *   Updated snapshots across several test files to reflect the new, more precise patching for reorders and keyed arrays.

**Benefits:**

*   **More Collaborative-Editing-Friendly Patches:** Key-based reordering generates patches that are significantly more resilient to concurrent modifications in arrays of keyed objects.
*   **Preserves User Intent:** Better captures the user's intent when they are merely reordering items, rather than treating it as a series of deletions and insertions at different indices.
*   **Handles Complex Scenarios:** The new logic correctly handles combinations of reordering, insertions, deletions, and content modifications within the same array.

This is a foundational improvement for generating robust patches for keyed arrays, crucial for collaborative environments.