### PR TITLE
refactor: preserve order in patch serialization

### DIFF
--- a/test/__snapshots__/api.test.ts.snap
+++ b/test/__snapshots__/api.test.ts.snap
@@ -16,7 +16,6 @@ exports[`module api > can include ifRevisionID 1`] = `
     "patch": {
       "id": "die-hard-iii",
       "set": {
-        "arr[1]": null,
         "slug._type": "slug",
       },
     },
@@ -31,6 +30,14 @@ exports[`module api > can include ifRevisionID 1`] = `
 ",
       },
       "id": "die-hard-iii",
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "set": {
+        "arr[1]": null,
+      },
     },
   },
 ]
@@ -51,7 +58,6 @@ exports[`module api > can pass different document ID 1`] = `
     "patch": {
       "id": "moop",
       "set": {
-        "arr[1]": null,
         "slug._type": "slug",
       },
     },
@@ -66,6 +72,14 @@ exports[`module api > can pass different document ID 1`] = `
 ",
       },
       "id": "moop",
+    },
+  },
+  {
+    "patch": {
+      "id": "moop",
+      "set": {
+        "arr[1]": null,
+      },
     },
   },
 ]

--- a/test/__snapshots__/diff-match-patch.test.ts.snap
+++ b/test/__snapshots__/diff-match-patch.test.ts.snap
@@ -4,14 +4,6 @@ exports[`diff match patch > does not use dmp for "privates" (underscore-prefixed
 [
   {
     "patch": {
-      "id": "die-hard-ix",
-      "set": {
-        "reviews[_key=="abc123"]._type": "reviewFromUserRepresentingMovieOrNovelOrSomethingVeryLongThatCanBeShownAsStars",
-      },
-    },
-  },
-  {
-    "patch": {
       "diffMatchPatch": {
         "useDmp": "@@ -7,8 +7,72 @@
  FromUser
@@ -19,6 +11,14 @@ exports[`diff match patch > does not use dmp for "privates" (underscore-prefixed
 ",
       },
       "id": "die-hard-ix",
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-ix",
+      "set": {
+        "reviews[_key=="abc123"]._type": "reviewFromUserRepresentingMovieOrNovelOrSomethingVeryLongThatCanBeShownAsStars",
+      },
     },
   },
 ]

--- a/test/__snapshots__/if-revision.test.ts.snap
+++ b/test/__snapshots__/if-revision.test.ts.snap
@@ -4,15 +4,6 @@ exports[`ifRevisionID > can apply revision constraint (inferred from document) 1
 [
   {
     "patch": {
-      "id": "die-hard-iii",
-      "ifRevisionID": "datrev",
-      "set": {
-        "rating": 4,
-      },
-    },
-  },
-  {
-    "patch": {
       "diffMatchPatch": {
         "title": "@@ -6,5 +6,20 @@
  ard 
@@ -21,6 +12,15 @@ exports[`ifRevisionID > can apply revision constraint (inferred from document) 1
 ",
       },
       "id": "die-hard-iii",
+      "ifRevisionID": "datrev",
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "set": {
+        "rating": 4,
+      },
     },
   },
 ]
@@ -30,15 +30,6 @@ exports[`ifRevisionID > can apply revision constraint (uppercase) 1`] = `
 [
   {
     "patch": {
-      "id": "die-hard-iii",
-      "ifRevisionID": "abc123",
-      "set": {
-        "rating": 4,
-      },
-    },
-  },
-  {
-    "patch": {
       "diffMatchPatch": {
         "title": "@@ -6,5 +6,20 @@
  ard 
@@ -47,6 +38,15 @@ exports[`ifRevisionID > can apply revision constraint (uppercase) 1`] = `
 ",
       },
       "id": "die-hard-iii",
+      "ifRevisionID": "abc123",
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "set": {
+        "rating": 4,
+      },
     },
   },
 ]

--- a/test/__snapshots__/set-unset.test.ts.snap
+++ b/test/__snapshots__/set-unset.test.ts.snap
@@ -29,14 +29,6 @@ exports[`set/unset > deep nested changes 1`] = `
 [
   {
     "patch": {
-      "id": "die-hard-iii",
-      "unset": [
-        "products[_key=="item-1"].variants[_key=="variant-2"]['lace-type']",
-      ],
-    },
-  },
-  {
-    "patch": {
       "diffMatchPatch": {
         "products[_key=="item-1"].comparisonFields['support-level']": "@@ -1,5 +1,8 @@
 -basic
@@ -48,6 +40,14 @@ exports[`set/unset > deep nested changes 1`] = `
 ",
       },
       "id": "die-hard-iii",
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "unset": [
+        "products[_key=="item-1"].variants[_key=="variant-2"]['lace-type']",
+      ],
     },
   },
 ]
@@ -88,7 +88,6 @@ exports[`set/unset > set + unset, nested changes 1`] = `
     "patch": {
       "id": "die-hard-iii",
       "set": {
-        "arr[1]": null,
         "slug._type": "slug",
       },
     },
@@ -105,19 +104,19 @@ exports[`set/unset > set + unset, nested changes 1`] = `
       "id": "die-hard-iii",
     },
   },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "set": {
+        "arr[1]": null,
+      },
+    },
+  },
 ]
 `;
 
 exports[`set/unset > simple root-level changes 1`] = `
 [
-  {
-    "patch": {
-      "id": "die-hard-iii",
-      "set": {
-        "rating": 4,
-      },
-    },
-  },
   {
     "patch": {
       "diffMatchPatch": {
@@ -128,6 +127,14 @@ exports[`set/unset > simple root-level changes 1`] = `
 ",
       },
       "id": "die-hard-iii",
+    },
+  },
+  {
+    "patch": {
+      "id": "die-hard-iii",
+      "set": {
+        "rating": 4,
+      },
     },
   },
 ]

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -21,7 +21,7 @@ describe('module api', () => {
 
   test('does not throw if ids do not match and id is provided', () => {
     const b = {...setAndUnset.b, _id: 'zing'}
-    expect(diffPatch(setAndUnset.a, b, {id: 'yup'})).toHaveLength(3)
+    expect(diffPatch(setAndUnset.a, b, {id: 'yup'})).not.toHaveLength(0)
   })
 
   test('pathToString throws on invalid path segments', () => {

--- a/test/data-types.test.ts
+++ b/test/data-types.test.ts
@@ -9,21 +9,29 @@ describe('diff data types', () => {
       {
         patch: {
           id: dataTypes.a._id,
-          set: {
-            isFeatured: false,
-            rating: 4.24,
-            year: 1995,
+
+          diffMatchPatch: {title: '@@ -6,5 +6,20 @@\n ard \n-3\n+with a Vengeance\n'},
+        },
+      },
+      {
+        patch: {
+          id: dataTypes.a._id,
+          set: {isFeatured: false, rating: 4.24},
+        },
+      },
+      {
+        patch: {
+          id: dataTypes.a._id,
+          diffMatchPatch: {
+            'characters[0]': '@@ -1,12 +1,12 @@\n-John McClane\n+Simon Gruber\n',
+            'slug.current': '@@ -6,7 +6,20 @@\n ard-\n-iii\n+with-a-vengeance\n',
           },
         },
       },
       {
         patch: {
-          id: 'die-hard-iii',
-          diffMatchPatch: {
-            title: '@@ -6,5 +6,20 @@\n ard \n-3\n+with a Vengeance\n',
-            'characters[0]': '@@ -1,12 +1,12 @@\n-John McClane\n+Simon Gruber\n',
-            'slug.current': '@@ -6,7 +6,20 @@\n ard-\n-iii\n+with-a-vengeance\n',
-          },
+          id: dataTypes.a._id,
+          set: {year: 1995},
         },
       },
     ])
@@ -60,25 +68,15 @@ describe('diff data types', () => {
 
   test('type changes', () => {
     expect(diffPatch(typeChange.a, typeChange.b)).toEqual([
-      {patch: {id: 'abc123', unset: ['unset', 'array[2].two.levels.deep']}},
+      {patch: {id: 'abc123', unset: ['unset']}},
+      {patch: {id: 'abc123', set: {number: 1337}}},
+      {patch: {diffMatchPatch: {string: '@@ -1,3 +1,3 @@\n-foo\n+bar\n'}, id: 'abc123'}},
+      {patch: {id: 'abc123', set: {'array[0]': 0, 'array[1]': 'one', bool: false}}},
+      {patch: {id: 'abc123', unset: ['array[2].two.levels.deep']}},
       {
         patch: {
           id: 'abc123',
-          set: {
-            'array[0]': 0,
-            'array[1]': 'one',
-            'array[2].two.levels.other': 'value',
-            bool: false,
-            number: 1337,
-            'object.b12': '12',
-            'object.f13': null,
-          },
-        },
-      },
-      {
-        patch: {
-          id: 'abc123',
-          diffMatchPatch: {string: '@@ -1,3 +1,3 @@\n-foo\n+bar\n'},
+          set: {'array[2].two.levels.other': 'value', 'object.b12': '12', 'object.f13': null},
         },
       },
     ])


### PR DESCRIPTION
This PR refactors the internal `serializePatches` function to use a recursive approach. The primary goal of this change is to better preserve the original order of operations as they are generated by `diffItem` when they are grouped into `SanityPatchOperations`.

Previously, `serializePatches` would filter all patches by type (set, unset, insert, dmp) and then combine them. This could lead to a reordering of operations if, for example, a `set` operation was diffed before an `unset` operation that should logically follow it.

The new recursive approach processes patches one by one:
*   It attempts to merge consecutive patches of the same type (e.g., multiple `set` operations can be combined into a single `set: {...}` object).
*   If a patch of a different type is encountered, the current accumulated patch operation object is emitted, and a new one is started for the new type.
*   `insert` operations always result in a new patch object being emitted, as they are not typically batched with other operation types in the same way.

**Key Changes:**

*   **Recursive `serializePatches`:**
    *   The `serializePatches` function now takes an optional `curr?: SanityPatchOperation` parameter to carry the currently accumulating patch object.
    *   It processes the head of the `patches` array:
        *   For `set` and `diffMatchPatch`: If `curr` is undefined or of a different type, a new `curr` is started. Otherwise, the operation is merged into the existing `curr`.
        *   For `unset`: Similar logic to `set`, but merges into `curr.unset[]`.
        *   For `insert`: If `curr` exists, it's emitted first, then the `insert` operation is emitted as a new patch object.
    *   This ensures that if the diffing process generates, for example, `set`, then `unset`, then `set` again, these will be serialized into distinct patch operation objects, preserving that logical sequence.
*   **Test Snapshot Updates:**
    *   Snapshots have been updated to reflect the new serialization order. In many cases, this results in more individual patch objects within a `SanityPatchMutation[]` array where previously operations might have been grouped less granularly or in a different order. For example, a `set` followed by a `diffMatchPatch` will now be two separate entries in the `SanityPatchMutation[]` array if they were generated in that order by `diffItem`.

**Rationale:**

*   **Order Preservation:** Ensures that the sequence of operations (e.g., an `unset` happening before a `set` on a related path) as determined by the diffing logic is maintained in the serialized output. This can be important for the logical application of patches, especially in more complex scenarios or when patches might be manipulated or inspected before application.
*   **Clearer Grouping:** While potentially leading to more patch objects in the array, the grouping is now more directly reflective of the sequence of changes.
*   **Foundation for Future Enhancements:** This recursive structure might be more adaptable for future features that require more nuanced control over patch grouping or ordering (e.g., reordering patches).

This change primarily affects the internal serialization and the structure of the output array in snapshots, aiming for a more robust and order-preserving serialization.
