### PR TITLE
refactor: rename itemA/itemB to source/target

### DIFF
--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -15,7 +15,7 @@ describe('module api', () => {
   test('throws if ids do not match', () => {
     const b = {...setAndUnset.b, _id: 'zing'}
     expect(() => diffPatch(setAndUnset.a, b)).toThrowError(
-      `_id on itemA and itemB not present or differs, specify document id the mutations should be applied to`,
+      `_id on source and target not present or differs, specify document id the mutations should be applied to`,
     )
   })
 


### PR DESCRIPTION
This PR performs a straightforward but important refactoring throughout the codebase: renaming the parameters `itemA` and `itemB` to `source` and `target` respectively.

This change applies to:
*   The public `diffPatch` function.
*   Internal functions like `diffItem`, `diffObject`, `diffArray`, `diffArrayByIndex`, and `getDiffMatchPatch` (where applicable, though some parts of `getDiffMatchPatch` already used source/target).
*   JSDoc comments and error messages.

**Key Changes:**

*   **Parameter Renaming:**
    *   In `diffPatch(itemA, itemB, ...)` is now `diffPatch(source, target, ...)`.
    *   In `diffItem(itemA, itemB, ...)` is now `diffItem(source, target, ...)`.
    *   Similar renames in `diffObject` and `diffArray`.
    *   The JSDoc for `getDiffMatchPatch` already used `source`/`target`, but internal variable names like `itemA`/`itemB` were updated where they existed.
*   **Documentation and Error Message Updates:**
    *   JSDoc `@param` tags updated to reflect the new names (e.g., `@param source - The first document/tree to compare`).
    *   Error messages updated, for example, the ID mismatch error now reads `_id on source and target not present or differs...`.

**Rationale:**

*   **Semantic Clarity:** `source` and `target` are more descriptive and standard terms for diffing operations, clearly indicating the initial state and the desired final state.
*   **Consistency:** Aligns the parameter naming with common conventions in diffing libraries and algorithms.
*   **Improved Readability:** Makes the code easier to understand at a glance, as the role of each parameter is more immediately obvious.

This is primarily a cosmetic and semantic improvement that enhances code clarity and maintainability without altering the core diffing logic. All tests continue to pass.
